### PR TITLE
Fix frontend object ID error

### DIFF
--- a/utils/collaborativeFiltering.js
+++ b/utils/collaborativeFiltering.js
@@ -148,38 +148,36 @@ export const buildInteractionMatrix = async (userIds = [], memeIds = []) => {
     console.log(`處理 ${targetUserIds.length} 個用戶和 ${targetMemeIds.length} 個迷因`)
 
     // 取得所有互動數據
-    const userIdList = targetUserIds.map((id) => id.toString())
-    const memeIdList = targetMemeIds.map((id) => id.toString())
-
+    // 使用 ObjectId 而不是字符串進行查詢
     const [likes, collections, comments, shares, views] = await Promise.all([
       Like.find({
-        user_id: { $in: userIdList },
-        meme_id: { $in: memeIdList },
+        user_id: { $in: targetUserIds },
+        meme_id: { $in: targetMemeIds },
       })
         .select('user_id meme_id createdAt')
         .lean(),
       Collection.find({
-        user_id: { $in: userIdList },
-        meme_id: { $in: memeIdList },
+        user_id: { $in: targetUserIds },
+        meme_id: { $in: targetMemeIds },
       })
         .select('user_id meme_id createdAt')
         .lean(),
       Comment.find({
-        user_id: { $in: userIdList },
-        meme_id: { $in: memeIdList },
+        user_id: { $in: targetUserIds },
+        meme_id: { $in: targetMemeIds },
         status: 'normal',
       })
         .select('user_id meme_id createdAt')
         .lean(),
       Share.find({
-        user_id: { $in: userIdList },
-        meme_id: { $in: memeIdList },
+        user_id: { $in: targetUserIds },
+        meme_id: { $in: targetMemeIds },
       })
         .select('user_id meme_id createdAt')
         .lean(),
       View.find({
-        user_id: { $in: userIdList },
-        meme_id: { $in: memeIdList },
+        user_id: { $in: targetUserIds },
+        meme_id: { $in: targetMemeIds },
       })
         .select('user_id meme_id createdAt')
         .lean(),
@@ -627,9 +625,9 @@ export const buildSocialGraph = async (userIds = []) => {
     }
 
     // 取得所有追隨關係
-    const userIdList = targetUserIds.map((id) => id.toString())
+    // 使用 ObjectId 而不是字符串進行查詢
     const follows = await Follow.find({
-      $or: [{ follower_id: { $in: userIdList } }, { following_id: { $in: userIdList } }],
+      $or: [{ follower_id: { $in: targetUserIds } }, { following_id: { $in: targetUserIds } }],
       status: 'active',
     })
       .select('follower_id following_id createdAt')


### PR DESCRIPTION
Fix `Cast to ObjectId failed` errors by removing unnecessary string conversions for ObjectId fields in collaborative filtering queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a209bb3-112c-4c78-b1a4-0d59bf70bd4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a209bb3-112c-4c78-b1a4-0d59bf70bd4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>